### PR TITLE
Make clear system evolution defines delta of state

### DIFF
--- a/examples/tutorials/latex/BluSTL_tutorial.tex
+++ b/examples/tutorials/latex/BluSTL_tutorial.tex
@@ -131,7 +131,7 @@ where
 Given a sampling time $\dt>0$, we discretize $\Sigma$ into 
 $\Sigma_d$ of the form
 \begin{eqnarray}
-x(t_{k+1}) &= &A^d x(t_k) + B^d_u u(t_k) + B^d_w w(t_k)  \label{eq:dynd} \\ 
+x(t_{k+1}) - x(t_k) &= &A^d x(t_k) + B^d_u u(t_k) + B^d_w w(t_k)  \label{eq:dynd} \\ 
  y(t_k) &=& C^d x(t_k) + D^d_u u(t_k) + D^d_w w(t_k)  \label{eq:outd}
 \end{eqnarray}
 


### PR DESCRIPTION
In equation (3) in BluSTL_tutorial.pdf, the equation suggests that
the discrete form of the system evolution defines the next state
as a whole. In reality, the system evolution defines the change
in the system state. The updated documentation has not been built
into the PDF due to the matlab script running into an infeasibility 
error part way through, truncating the graphs. There were also 
mild formatting issues with how the screenshots are integrated 
into the PDF.